### PR TITLE
Add nlohmann_json_io_dep that doesn't define JSON_NO_IO

### DIFF
--- a/src/lib/nlohmann_json/meson.build
+++ b/src/lib/nlohmann_json/meson.build
@@ -4,8 +4,22 @@ nlohmann_json = dependency('nlohmann_json',
                            required: get_variable('libcommon_enable_json', true))
 if not nlohmann_json.found()
   nlohmann_json_dep = nlohmann_json
+  nlohmann_json_io_dep = nlohmann_json
   subdir_done()
 endif
+
+nlohmann_json_io = static_library(
+  'nlohmann_json_io',
+  'ToDisposableBuffer.cxx',
+  dependencies: nlohmann_json,
+  include_directories: inc,
+)
+
+# If you really need IO streams, you get this special dependency
+nlohmann_json_io_dep = declare_dependency(
+  link_with: nlohmann_json_io,
+  dependencies: nlohmann_json,
+)
 
 nlohmann_json_dep = declare_dependency(
   # no iostreams, please


### PR DESCRIPTION
The 'stretch' target in config-server requires nlohmann/json without JSON_NO_IO and previously didn't even add a dependency for nlohmann json at all. This is the first step to fix this.